### PR TITLE
Max depth and offset

### DIFF
--- a/Shaders/BulgePinch.fx
+++ b/Shaders/BulgePinch.fx
@@ -101,6 +101,12 @@ float4 PBDistort(float4 pos : SV_Position, float2 texcoord : TEXCOORD0) : SV_TAR
         inDepthBounds = out_depth <= depth_threshold;
     }
        
+    float blending_factor;
+    if(render_type)
+        blending_factor = lerp(0, 1 - percent, blending_amount);
+    else
+        blending_factor = blending_amount;
+
     if (tension_radius >= dist && inDepthBounds)
     {
         if(use_offset_coords){
@@ -110,7 +116,8 @@ float4 PBDistort(float4 pos : SV_Position, float2 texcoord : TEXCOORD0) : SV_TAR
                 color = tex2D(samplerColor, texcoord);
         } else
             color = tex2D(samplerColor, tc);
-        color = applyBlendingMode(base, color, 1-min(tension_radius, 1)); 
+
+        color.rgb = ComHeaders::Blending::Blend(render_type, base, color, blending_factor);
     }
     else {
         color = tex2D(samplerColor, texcoord);

--- a/Shaders/Include/BulgePinch.fxh
+++ b/Shaders/Include/BulgePinch.fxh
@@ -1,4 +1,5 @@
 #include "Include/RadegastShaders.CommonPositional.fxh"
+#include "Include/RadegastShaders.Depth.fxh"
 #include "Include/RadegastShaders.BlendingModes.fxh"
 
 uniform float magnitude <

--- a/Shaders/Include/RadegastShaders.BlendingModes.fxh
+++ b/Shaders/Include/RadegastShaders.BlendingModes.fxh
@@ -1,47 +1,20 @@
-uniform int blending_mode <
-    ui_type = "combo";
-    ui_label = "Blending Mode";
-    ui_items = "Normal\0Add\0Multiply\0Subtract\0Divide\0Darker\0Lighter\0";
-    ui_tooltip = "Choose a blending mode.";
-> = 0;
+#include "Blending.fxh"
 
-float4 applyBlendingMode(float4 base, float4 color) { 
-    switch(blending_mode) {
-        case 1:
-            return color + base;
-        case 2:
-            return color * base;
-        case 3:
-            return color - base;
-        case 4:
-            return color / base;
-        case 5:
-            if(length(color.rgb) > length(base.rgb)) return base;
-            return color;
-        case 6:
-            if(length(color.rgb) < length(base.rgb)) return base;
-            return color;
-    }  
-    return color;
-}
+BLENDING_COMBO(
+    render_type, 
+    "Blending Mode", 
+    "Blends the effect with the previous layers.",
+    "Blending",
+    false,
+    0,
+    0
+);
 
-float4 applyBlendingMode(float4 base, float4 color, float percent) {    
-    switch(blending_mode) {
-        case 1:
-            return lerp(base, color + base, percent);
-        case 2:
-            return lerp(base, color * base, percent);
-        case 3:
-            return lerp(base, color - base, percent);
-        case 4:
-            return lerp(base, color / base, percent);
-        case 5:
-            if(length(color.rgb) > length(base.rgb)) return base;
-            return color;
-        case 6:
-            if(length(color.rgb) < length(base.rgb)) return base;
-            return color;
-    }  
-    return color;
-
-}
+uniform float blending_amount <
+    ui_type = "slider";
+    ui_label = "Opacity";
+    ui_category = "Blending"
+    ui_tooltip = "Adjusts the blending amount.";
+    ui_min = 0.0;
+    ui_max = 1.0;
+> = 1.0;

--- a/Shaders/Include/RadegastShaders.CommonPositional.fxh
+++ b/Shaders/Include/RadegastShaders.CommonPositional.fxh
@@ -31,6 +31,7 @@ uniform float tension <
     #else
         ui_type = "slider";
     #endif
+    ui_label = "Tension";
     ui_min = 0.; ui_max = 10.; ui_step = 0.001;
 > = 1.0;
 
@@ -48,6 +49,7 @@ uniform float aspect_ratio <
 uniform bool use_offset_coords <
     ui_label = "Use Offset Coordinates";
     ui_tooltip = "Display the distortion in any location besides its original coordinates.";
+    ui_category = "Offset";
 > = 0;
 
 uniform float2 offset_coords <
@@ -56,6 +58,8 @@ uniform float2 offset_coords <
     #else 
         ui_type = "slider";
     #endif
+    ui_label = "Offset Coordinates";
+    ui_category = "Offset";
     ui_min = 0.0;
     ui_max = 1.0;
 > = float2(0.5, 0.5);

--- a/Shaders/Include/RadegastShaders.CommonPositional.fxh
+++ b/Shaders/Include/RadegastShaders.CommonPositional.fxh
@@ -45,16 +45,20 @@ uniform float aspect_ratio <
     ui_max = 100.0;
 > = 0;
 
-uniform float min_depth <
+uniform bool use_offset_coords <
+    ui_label = "Use Offset Coordinates";
+    ui_tooltip = "Display the distortion in any location besides its original coordinates.";
+> = 0;
+
+uniform float2 offset_coords <
     #if __RESHADE__ < 40000
         ui_type = "drag";
     #else 
         ui_type = "slider";
     #endif
-    ui_label="Minimum Depth";
-    ui_min=0.0;
-    ui_max=1.0;
-> = 0;
+    ui_min = 0.0;
+    ui_max = 1.0;
+> = float2(0.5, 0.5);
 
 uniform float anim_rate <
     source = "timer";

--- a/Shaders/Include/RadegastShaders.Depth.fxh
+++ b/Shaders/Include/RadegastShaders.Depth.fxh
@@ -5,6 +5,7 @@ uniform float depth_threshold <
         ui_type = "slider";
     #endif
     ui_label="Depth Threshold";
+    ui_category="Depth";
     ui_min=0.0;
     ui_max=1.0;
 > = 0;
@@ -12,11 +13,13 @@ uniform float depth_threshold <
 uniform int depth_mode <
     ui_type = "combo";
     ui_label = "Depth Mode";
+    ui_category="Depth";
     ui_items = "Minimum\0Maximum\0";
     ui_tooltip = "Mask the effect by using the depth of the scene.";
 > = 0;
 
 uniform bool set_max_depth_behind <
     ui_label = "Set Distortion Behind Foreground";
+    ui_category="Depth";
     ui_tooltip = "(Maximum Depth Threshold Mode only) When enabled, sets the distorted area behind the objects that should come in front of it.";
 > = 0;

--- a/Shaders/Include/RadegastShaders.Depth.fxh
+++ b/Shaders/Include/RadegastShaders.Depth.fxh
@@ -1,0 +1,22 @@
+uniform float depth_threshold <
+    #if __RESHADE__ < 40000
+        ui_type = "drag";
+    #else 
+        ui_type = "slider";
+    #endif
+    ui_label="Depth Threshold";
+    ui_min=0.0;
+    ui_max=1.0;
+> = 0;
+
+uniform int depth_mode <
+    ui_type = "combo";
+    ui_label = "Depth Mode";
+    ui_items = "Minimum\0Maximum\0";
+    ui_tooltip = "Mask the effect by using the depth of the scene.";
+> = 0;
+
+uniform bool set_max_depth_behind <
+    ui_label = "Set distortion behind depth?";
+    ui_tooltip = "(Maximum Depth Threshold Mode only) When enabled, sets the distorted area behind the objects that should come in front of it.";
+> = 0;

--- a/Shaders/Include/RadegastShaders.Depth.fxh
+++ b/Shaders/Include/RadegastShaders.Depth.fxh
@@ -17,6 +17,6 @@ uniform int depth_mode <
 > = 0;
 
 uniform bool set_max_depth_behind <
-    ui_label = "Set distortion behind depth?";
+    ui_label = "Set Distortion Behind Foreground";
     ui_tooltip = "(Maximum Depth Threshold Mode only) When enabled, sets the distorted area behind the objects that should come in front of it.";
 > = 0;

--- a/Shaders/Include/SlitScan.fxh
+++ b/Shaders/Include/SlitScan.fxh
@@ -1,3 +1,5 @@
+#include "Include/RadegastShaders.Depth.fxh"
+
 uniform float x_col <
     #if __RESHADE__ < 40000
         ui_type = "drag";
@@ -22,18 +24,6 @@ uniform float scan_speed <
     ui_max = 3.0;
     ui_min = 0.0;
 > = 1.0;
-
-uniform float min_depth <
-    #if __RESHADE__ < 40000
-        ui_type = "drag";
-    #else 
-        ui_type = "slider";
-    #endif
-    ui_label="Minimum Depth";
-    ui_tooltip="Unmasks anything before a set depth.";
-    ui_min=0.0;
-    ui_max=1.0;
-> = 0;
 
 uniform int direction <
     ui_type = "combo";

--- a/Shaders/Include/Swirl.fxh
+++ b/Shaders/Include/Swirl.fxh
@@ -1,3 +1,4 @@
+#include "Include/RadegastShaders.Depth.fxh"
 #include "Include/RadegastShaders.CommonPositional.fxh"
 #include "Include/RadegastShaders.BlendingModes.fxh"
 #include "Include/RadegastShaders.Transforms.fxh"

--- a/Shaders/Include/Swirl.fxh
+++ b/Shaders/Include/Swirl.fxh
@@ -1,7 +1,7 @@
 #include "Include/RadegastShaders.Depth.fxh"
 #include "Include/RadegastShaders.CommonPositional.fxh"
-#include "Include/RadegastShaders.BlendingModes.fxh"
 #include "Include/RadegastShaders.Transforms.fxh"
+#include "Include/RadegastShaders.BlendingModes.fxh"
 
 uniform int swirl_mode <
     ui_type="combo";
@@ -59,3 +59,4 @@ uniform int animate <
     ui_items = "No\0Yes\0";
     ui_tooltip = "Animates the swirl, moving it clockwise and counterclockwise.";
 > = 0;
+

--- a/Shaders/Include/TinyPlanet.fxh
+++ b/Shaders/Include/TinyPlanet.fxh
@@ -26,6 +26,13 @@ uniform float center_y <
     ui_max = 360.0;
 > =0;
 
+uniform int mode <
+    ui_type = "combo";
+    ui_label = "Mode";
+    ui_items = "Tiny Planet\0Kaleidoscope\0";
+    ui_tooltip = "Changes the mode between Tiny Planet and Kaleidoscope mode.";
+> = 0;
+
 uniform float2 offset <
     #if __RESHADE__ < 40000
         ui_type = "drag";

--- a/Shaders/Include/Wave.fxh
+++ b/Shaders/Include/Wave.fxh
@@ -1,3 +1,4 @@
+#include "Include/RadegastShaders.Depth.fxh"
 #include "Include/RadegastShaders.BlendingModes.fxh"
 
 uniform int wave_type <
@@ -27,7 +28,7 @@ uniform float period <
     #else
         ui_type = "slider";
     #endif
-    ui_label = "Phase";
+    ui_label = "Period";
     ui_min = 0.1; 
     ui_max = 10.0;
     ui_tooltip = "The wavelength of the distortion. Smaller values make for a longer wavelength.";
@@ -56,17 +57,6 @@ uniform float phase <
     ui_max = 5.0;
     ui_tooltip = "The offset being applied to the distortion's waves.";
 > = 0.0;
-
-uniform float min_depth <
-    #if __RESHADE__ < 40000
-        ui_type = "drag";
-    #else
-        ui_type = "slider";
-    #endif
-    ui_label="Minimum Depth";
-    ui_min=0.0;
-    ui_max=1.0;
-> = 0;
 
 uniform int animate <
     ui_type = "combo";

--- a/Shaders/Include/ZigZag.fxh
+++ b/Shaders/Include/ZigZag.fxh
@@ -1,3 +1,4 @@
+#include "Include/RadegastShaders.Depth.fxh"
 #include "Include/RadegastShaders.CommonPositional.fxh"
 #include "Include/RadegastShaders.BlendingModes.fxh"
 #include "Include/RadegastShaders.Transforms.fxh"

--- a/Shaders/SlitScan.fx
+++ b/Shaders/SlitScan.fx
@@ -107,8 +107,11 @@ void SlitScan(float4 pos : SV_Position, float2 texcoord : TEXCOORD0, out float4 
             break;
         case 2:
         case 3:
-            if(texcoord.y >= slice_to_fill - pix_w && texcoord.y <= slice_to_fill + pix_w)
-                col_to_write.rgba = col_pixels.rgba;
+            if(texcoord.y >= slice_to_fill - pix_w && texcoord.y <= slice_to_fill + pix_w){
+                
+                    col_to_write.rgba = col_pixels.rgba;
+               
+            }
             else
                 discard;
             break;
@@ -161,10 +164,21 @@ void SlitScanPost(float4 pos : SV_Position, float2 texcoord : TEXCOORD0, out flo
             mask = step(scan_col, texcoord.y);
             break;
     }
-    if(depth >= min_depth)
+    
+    bool inDepthBounds;
+    if(depth_mode == 0)
+        inDepthBounds = depth >= depth_threshold;
+    else 
+        inDepthBounds = depth <= depth_threshold;
+
+    if(inDepthBounds)
         color = lerp(screen, scanned, mask);
     else
         color = screen; 
+
+
+    
+    
 }
 
 technique SlitScan <

--- a/Shaders/Swirl.fx
+++ b/Shaders/Swirl.fx
@@ -107,21 +107,35 @@ float4 Swirl(float4 pos : SV_Position, float2 texcoord : TEXCOORD0) : SV_TARGET
        
     if (inDepthBounds)
     {
-        if(use_offset_coords){
-            if((!swirl_mode && percent) || (swirl_mode && dist <= radius))
+        if(use_offset_coords)
+        {
+            if((!swirl_mode && percent) || (swirl_mode && theta))
                 color = tex2D(samplerColor, tc);
             else
                 color = tex2D(samplerColor, texcoord);
         } else
             color = tex2D(samplerColor, tc);
-        color = applyBlendingMode(base, color, min(abs(theta), 1));
+
+        float blending_factor;
+        if(swirl_mode)
+            blending_factor = blending_amount;
+        else {
+            if(render_type)
+                blending_factor = lerp(0, dist_radius * tension_radius * 10, blending_amount);
+            else
+                blending_factor = blending_amount;
+        }
+        if((!swirl_mode && percent) || (swirl_mode && dist <= radius))
+            color.rgb = ComHeaders::Blending::Blend(render_type, base, color, blending_factor);
+            
     }
     else
     {
         color = base;
     }
 
-    if(set_max_depth_behind) {
+    if(set_max_depth_behind) 
+    {
         const float mask_front = ReShade::GetLinearizedDepth(texcoord).r;
         if(mask_front < depth_threshold)
             color = tex2D(samplerColor, texcoord);

--- a/Shaders/Swirl.fx
+++ b/Shaders/Swirl.fx
@@ -43,65 +43,93 @@ float4 Swirl(float4 pos : SV_Position, float2 texcoord : TEXCOORD0) : SV_TARGET
     float4 base = tex2D(samplerColor, texcoord);
     const float ar_raw = 1.0 * (float)BUFFER_HEIGHT / (float)BUFFER_WIDTH;
     float ar = lerp(ar_raw, 1, aspect_ratio * 0.01);
+
     const float depth = ReShade::GetLinearizedDepth(texcoord).r;
     float2 center = coordinates  / 2.0;
+    float2 offset_center = offset_coords / 2.0;
 
     if (use_mouse_point) 
         center = float2(mouse_coordinates.x * BUFFER_RCP_WIDTH / 2.0, mouse_coordinates.y * BUFFER_RCP_HEIGHT / 2.0);
 
     float2 tc = texcoord - center;
+
     float4 color;
 
     center.x /= ar;
+    offset_center.x /= ar;
+
     tc.x /= ar;
 
     const float dist = distance(tc, center);
-    if (depth >= min_depth)
-    {
-        const float dist_radius = radius-dist;
-        const float tension_radius = lerp(radius-dist, radius, tension);
-        float percent; 
-        float theta; 
+    const float dist_radius = radius-dist;
+    const float tension_radius = lerp(radius-dist, radius, tension);
+    const float tension_dist = lerp(dist_radius, tension_radius, tension);
+    float percent; 
+    float theta; 
 
-        if(swirl_mode == 0){
-            percent = max(dist_radius, 0) / tension_radius;   
-            if(inverse && dist < radius)
-                percent = 1 - percent;     
+    if(swirl_mode == 0){
+        percent = max(dist_radius, 0) / tension_radius;   
+        if(inverse && dist < radius)
+            percent = 1 - percent;     
         
-            if(dist_radius > radius-inner_radius)
-                percent = 1;
-            theta = percent * percent * radians(angle * (animate == 1 ? sin(anim_rate * 0.0005) : 1.0));
-        }
-        else
-        {
-            float splice_width = (tension_radius-inner_radius) / number_splices;
-            splice_width = frac(splice_width);
-            float cur_splice = max(dist_radius,0)/splice_width;
-            cur_splice = cur_splice - frac(cur_splice);
-            float splice_angle = (angle / number_splices) * cur_splice;
-            if(dist_radius > radius-inner_radius)
-                splice_angle = angle;
-            theta = radians(splice_angle * (animate == 1 ? sin(anim_rate * 0.0005) : 1.0));
-        }
+        if(dist_radius > radius-inner_radius)
+            percent = 1;
+        theta = percent * percent * radians(angle * (animate == 1 ? sin(anim_rate * 0.0005) : 1.0));
+    } else {
+        float splice_width = (tension_radius-inner_radius) / number_splices;
+        splice_width = frac(splice_width);
+        float cur_splice = max(dist_radius,0)/splice_width;
+        cur_splice = cur_splice - frac(cur_splice);
+        float splice_angle = (angle / number_splices) * cur_splice;
+        if(dist_radius > tension_radius-inner_radius)
+            splice_angle = angle;
+        theta = radians(splice_angle * (animate == 1 ? sin(anim_rate * 0.0005) : 1.0));
+    }
 
-        tc = mul(swirlTransform(theta), tc-center);
+    tc = mul(swirlTransform(theta), tc-center);
+    if(use_offset_coords) {
+        tc += (2 * offset_center);
+    }
+    else 
         tc += (2 * center);
-        tc.x *= ar;    
-      
-        color = tex2D(samplerColor, tc);
-        color = applyBlendingMode(base, color, percent * percent);
+    tc.x *= ar;  
+        
+    float out_depth;
+    bool inDepthBounds;
+    if (depth_mode == 0) {
+        out_depth =  ReShade::GetLinearizedDepth(texcoord).r;
+        inDepthBounds = out_depth >= depth_threshold;
+    }
+    else{
+        out_depth = ReShade::GetLinearizedDepth(tc).r;
+        inDepthBounds = out_depth <= depth_threshold;
+    }
+       
+    if (inDepthBounds)
+    {
+        if(use_offset_coords){
+            if((!swirl_mode && percent) || (swirl_mode && dist <= radius))
+                color = tex2D(samplerColor, tc);
+            else
+                color = tex2D(samplerColor, texcoord);
+        } else
+            color = tex2D(samplerColor, tc);
+        color = applyBlendingMode(base, color, min(abs(theta), 1));
     }
     else
     {
         color = base;
     }
 
-    
+    if(set_max_depth_behind) {
+        const float mask_front = ReShade::GetLinearizedDepth(texcoord).r;
+        if(mask_front < depth_threshold)
+            color = tex2D(samplerColor, texcoord);
+    }
 
     return color;
    
 }
-
 
 // Technique
 technique Swirl< ui_label="Swirl";>

--- a/Shaders/Wave.fx
+++ b/Shaders/Wave.fx
@@ -99,6 +99,15 @@ float4 Wave(float4 pos : SV_Position, float2 texcoord : TEXCOORD0) : SV_TARGET
 
     tc.x *= ar;
 
+    float blending_factor;
+    if(render_type)
+        blending_factor = lerp(0, abs(amplitude)* lerp(10, 1, abs(amplitude)), blending_amount);
+    else
+        blending_factor = blending_amount;
+    
+    color.rgb = ComHeaders::Blending::Blend(render_type, base, color, blending_factor);
+
+
     float out_depth;
     bool inDepthBounds;
     if ( depth_mode == 0) {
@@ -111,7 +120,8 @@ float4 Wave(float4 pos : SV_Position, float2 texcoord : TEXCOORD0) : SV_TARGET
 
     if(inDepthBounds){
         color = tex2D(samplerColor, tc);
-        color = applyBlendingMode(base, color);
+    
+        color.rgb = ComHeaders::Blending::Blend(render_type, base, color, blending_factor);
     }
     else
     {

--- a/Shaders/ZigZag.fx
+++ b/Shaders/ZigZag.fx
@@ -92,18 +92,30 @@ float4 ZigZag(float4 pos : SV_Position, float2 texcoord : TEXCOORD0) : SV_TARGET
         inDepthBounds = out_depth <= depth_threshold;
     }
        
+    float blending_factor;
+    if(render_type) 
+        blending_factor = lerp(0, percentSquared, blending_amount);
+    else
+        blending_factor = blending_amount;
     if (inDepthBounds)
     {
         if(use_offset_coords){
             float2 offset_coords_adjust = offset_coords;
             offset_coords_adjust.x *= ar;
             if(dist <= tension_radius)
+            {
                 color = tex2D(samplerColor, tc);
+                color.rgb = ComHeaders::Blending::Blend(render_type, base, color, blending_factor);
+            }
             else
                 color = tex2D(samplerColor, texcoord);
         } else
+        {
             color = tex2D(samplerColor, tc);
-        color = applyBlendingMode(base, color, min(abs(theta), 1));
+            color.rgb = ComHeaders::Blending::Blend(render_type, base, color, blending_factor);
+        }
+        
+        
     }
     else
     {


### PR DESCRIPTION
Updates:
- Added a new "Depth Mode" parameter and changed "Minimum Depth" to "Depth Threshold".
  - Minimum  "Depth Mode" will use the old behavior which distorts the background, defaulting the Depth Threshold to 1.00, or basically distorting everything.
  - Maximum "Depth Mode" will distort the foreground, set the "Depth Threshold" to 0 and increase the value to work the distortion in from the foreground.
- Added "Offset Coordinates" and "Use Offset Coordinates" parameters.
  - "Use Offset Coordinates will change the behavior of the "Coordinates" parameter.
    - "Coordinates" will become the output location of the distortion, whereas "Offset Coordinates" will be the sampling location.
 - Added implementation of the new common blending library, which allows for more blending options. 


Fixes:
- The Coordinates parameter should work as intended now for all shaders, with (0, 0) being the top left and (1, 1) being the bottom right.

